### PR TITLE
Fix regex for file path

### DIFF
--- a/SdlLogs/SdlLogs.sublime-syntax
+++ b/SdlLogs/SdlLogs.sublime-syntax
@@ -10,7 +10,7 @@ variables:
   date_time:     '\[\d{1,2} \w{1,3} \d{1,} \d{1,2}:\d{1,2}:\d{1,2},\d{1,}\]'
   id:            '\[0x[a-fA-F0-9]+\]'
   component:     '\[[A-z]+\]'
-  path:          ' \/?[\w|\/]*\.(cc|cpp|h|hpp)'
+  path:          ' \/?[\w|\/|\.]*\.(cc|cpp|h|hpp)'
   line:          ':\d* *'
   message:       '.*'
   junk:          ' /(.*)/sdl_core/src/'


### PR DESCRIPTION
Path to a file could contain '.' symbol.
And in this case, highlighting does not work.